### PR TITLE
Use official SwiftLint Package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: "5.7.0"
       - uses: actions/checkout@v2
       - name: Build
         run: swift build

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,16 +1,75 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "SwiftLintPlugin",
-        "repositoryURL": "https://github.com/usami-k/SwiftLintPlugin",
-        "state": {
-          "branch": "main",
-          "revision": "f844a46b908910a34695fc429e2030b9e7003105",
-          "version": null
-        }
+  "pins" : [
+    {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "a9e6df65d8e31e0fa6e8a05ffe40ecd54a645871"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "e07287b891838498342e1eb0a358635faa4a5816"
+      }
+    },
+    {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint",
+      "state" : {
+        "branch" : "main",
+        "revision" : "4bd7da32eac56015855069335bc8ffa3042514fb"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "4d0f62f561458cbe1f732171e625f03195151b60",
+        "version" : "7.0.1"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "01835dc202670b5bb90d07f3eae41867e9ed29f6",
+        "version" : "5.0.1"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -17,22 +17,21 @@ let package = Package(
         ),
     ],
     dependencies: [
-        // The following PRs will be merged into the main branch and replaced with t and the official
-        // https://github.com/realm/SwiftLint/pull/4176
-        .package(url: "https://github.com/usami-k/SwiftLintPlugin", branch: "main"),
+        // TODO: versioning
+        .package(url: "https://github.com/realm/SwiftLint", branch: "main"),
     ],
     targets: [
         .target(
             name: "Parchment",
             plugins: [
-                .plugin(name: "SwiftLintPlugin", package: "SwiftLintPlugin"),
+                .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
             ]
         ),
         .target(
             name: "ParchmentDefault",
             dependencies: [.target(name: "Parchment")],
             plugins: [
-                .plugin(name: "SwiftLintPlugin", package: "SwiftLintPlugin"),
+                .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
             ]
         ),
         .testTarget(


### PR DESCRIPTION
## Problem

The official SwiftLint did not support Plugin, so third-party libraries were used

## Solution

Changed to use the official package because the official version now supports Plugin.