### PR TITLE
feture/strict concurrency check

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,11 @@ let package = Package(
     targets: [
         .target(
             name: "Parchment",
+            swiftSettings: [
+                .unsafeFlags([
+                    "-strict-concurrency=complete"
+                ])
+            ],
             plugins: [
                 .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
             ]
@@ -30,6 +35,11 @@ let package = Package(
         .target(
             name: "ParchmentDefault",
             dependencies: [.target(name: "Parchment")],
+            swiftSettings: [
+                .unsafeFlags([
+                    "-strict-concurrency=complete"
+                ])
+            ],
             plugins: [
                 .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
             ]

--- a/Sources/ParchmentDefault/DeviceDataMutation.swift
+++ b/Sources/ParchmentDefault/DeviceDataMutation.swift
@@ -11,11 +11,16 @@
     import UIKit
 
     public struct DeviceDataMutation: Mutation {
-        private let deviceParams = [
-            "Model": UIDevice.current.name,
-            "OS": UIDevice.current.systemName,
-            "OS Version": UIDevice.current.systemVersion
-        ]
+        private let deviceParams: [String: Any]
+
+        @MainActor
+        public init(device: UIDevice) {
+            deviceParams = [
+                "Model": device.name,
+                "OS": device.systemName,
+                "OS Version": device.systemVersion
+            ]
+        }
 
         public func transform(_ event: any Loggable, id _: LoggerComponentID) -> any Loggable {
             let log: LoggableDictonary = [

--- a/Tests/ParchmentDefaultTests/MutationTest.swift
+++ b/Tests/ParchmentDefaultTests/MutationTest.swift
@@ -29,9 +29,9 @@ private enum Event: Loggable {
 
 class MutationTests: XCTestCase {
     // 的確なテストに直す
-    func testTransform() throws {
+    @MainActor func testTransform() throws {
         let event = Event.hoge
-        let mutation: [Mutation] = [DeviceDataMutation()]
+        let mutation: [Mutation] = [DeviceDataMutation(device: .current)]
 
         let newEvent = mutation.transform(event, id: .init("hoge"))
 


### PR DESCRIPTION
## Problem

If the `strict-concurrency` setting is not enabled, Swift 6 will not be able to understand the code that results in errors.

## Solution

set strict-concurrency to complete