### PR TITLE
Changed to depend on SQLite.swift

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "sqlite.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stephencelis/SQLite.swift.git",
+      "state" : {
+        "revision" : "7a2e3cd27de56f6d396e84f63beefd0267b55ccb",
+        "version" : "0.14.1"
+      }
+    },
+    {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.14.1")
     ],
     targets: [
         .target(
@@ -30,7 +31,10 @@ let package = Package(
         ),
         .target(
             name: "ParchmentDefault",
-            dependencies: [.target(name: "Parchment")],
+            dependencies: [
+                .target(name: "Parchment"),
+                .product(name: "SQLite", package: "SQLite.swift")
+            ],
             swiftSettings: [
                 .unsafeFlags([
                     "-strict-concurrency=complete"

--- a/Sources/Parchment/LoggerBundler.swift
+++ b/Sources/Parchment/LoggerBundler.swift
@@ -80,7 +80,7 @@ public final actor LoggerBundler {
 //                """)
                 return
             }
-            await buffer.save(records)
+            try? await buffer.save(records)
         }
     }
 
@@ -88,7 +88,7 @@ public final actor LoggerBundler {
         let isSucceeded = await logger.send(records)
         let shouldBuffering = !isSucceeded && (configMap[logger.id]?.allowBuffering != .some(false))
         if shouldBuffering {
-            await buffer.save(records)
+            try? await buffer.save(records)
         } else if !isSucceeded {
 //            console()?.log("""
 //            ⚠ The logger(id=\(logger.id.value)) failed to log an event.

--- a/Sources/Parchment/TrackingEventBuffer.swift
+++ b/Sources/Parchment/TrackingEventBuffer.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 public protocol TrackingEventBuffer: Sendable {
-    func save(_ event: [BufferRecord]) async
-    func load(limit: Int64) async -> [BufferRecord]
-    func count() async -> Int
+    func save(_ event: [BufferRecord]) async throws
+    func load(limit: Int?) async throws -> [BufferRecord]
+    func count() async throws -> Int
 }
 
 public extension TrackingEventBuffer {
-    func load() async -> [BufferRecord] {
-        await load(limit: -1)
+    func load() async throws -> [BufferRecord] {
+        try await load(limit: nil)
     }
 }

--- a/Sources/ParchmentDefault/RegularlyPollingScheduler.swift
+++ b/Sources/ParchmentDefault/RegularlyPollingScheduler.swift
@@ -24,8 +24,8 @@ public struct RegularlyPollingScheduler: BufferedEventFlushScheduler, Sendable {
         AsyncThrowingStream { continuation in
             Task {
                 while !Task.isCancelled {
-                    let records = await buffer.load()
-                    continuation.yield(records)
+                    let records = try? await buffer.load()
+                    continuation.yield(records ?? [])
                     do {
                         try await Task.sleep(nanoseconds: UInt64(timeInterval) * 1000_000_000)
                     } catch {
@@ -37,10 +37,10 @@ public struct RegularlyPollingScheduler: BufferedEventFlushScheduler, Sendable {
 
             Task {
                 while !Task.isCancelled {
-                    let count = await buffer.count()
-                    if limitOnNumberOfEvent < count {
-                        let records = await buffer.load()
-                        continuation.yield(records)
+                    let count = try? await buffer.count()
+                    if limitOnNumberOfEvent < (count ?? 0) {
+                        let records = try? await buffer.load()
+                        continuation.yield(records ?? [])
                     }
                     do {
                         try await Task.sleep(nanoseconds: 1000_000_000)

--- a/Sources/ParchmentDefault/SQLiteBuffer.swift
+++ b/Sources/ParchmentDefault/SQLiteBuffer.swift
@@ -5,253 +5,94 @@
 //  Created by k-kohey on 2021/10/27.
 //
 
-import Foundation
 import Parchment
-import SQLite3
+import SQLite
+import Foundation
 
 public final actor SQLiteBuffer: TrackingEventBuffer {
-    enum SQLiteBufferError: Error {
-        case dbfileCanNotBeenOpend
-        case failedToCreateSQLiteTable
+    private enum Column {
+        static let id = Expression<String>("id")
+        static let destination = Expression<String>("destination")
+        static let eventName = Expression<String>("eventName")
+        static let parameters = Expression<Data>("parameters")
+        static let timestamp = Expression<Date>("timestamp")
     }
 
-    private var dbPointer: OpaquePointer?
+    private let db: Connection
+    private let events: Table
 
-    public init() throws {
+    public init(tableName: String = "Events") throws {
         let dbFilePath = try FileManager.default.url(
             for: .documentDirectory,
             in: .userDomainMask,
             appropriateFor: nil,
             create: true
-        ).appendingPathComponent("Events.db")
+        ).appendingPathComponent("Events.sqlite3")
 
-//        console()?.log("Events.db is created on \(dbFilePath.absoluteString)")
+        db = try Connection(dbFilePath.absoluteString)
+        events = Table(tableName)
 
-        if sqlite3_open(dbFilePath.path, &dbPointer) != SQLITE_OK {
-            throw SQLiteBufferError.dbfileCanNotBeenOpend
-        }
 
-        if sqlite3_exec(
-            dbPointer,
-            """
-            CREATE TABLE IF NOT EXISTS Events (
-                id TEXT PRIMARY KEY,
-                destination TEXT NOT NULL,
-                timestamp TIMESTAMP NOT NULL,
-                eventName TEXT NOT NULL,
-                parameters TEXT NOT NULL
-            )
-            """,
-            nil,
-            nil,
-            nil
-        ) != SQLITE_OK {
-            throw SQLiteBufferError.failedToCreateSQLiteTable
-        }
+        try db.run(
+            events.create(ifNotExists: true) { t in
+                t.column(Column.id, primaryKey: true)
+                t.column(Column.destination)
+                t.column(Column.eventName)
+                t.column(Column.parameters)
+                t.column(Column.timestamp)
+            }
+        )
     }
 
-    public func save(_ e: [BufferRecord]) async {
-        let query = """
-        INSERT INTO Events (
-            id,
-            destination,
-            timestamp,
-            eventName,
-            parameters
-        ) VALUES \(e.map { _ in "(?, ?, ?, ?, ?)" }.joined(separator: ", "))
-        """
-
-        let context = prepare(query: query)
-
-        defer {
-            sqlite3_finalize(context)
-        }
-
-        for (index, e) in e.enumerated() {
-            let valueIndex = { (offset: Int) -> Int32 in
-                let numberOfColumns = 5
-                return Int32(index * numberOfColumns + offset)
-            }
-            if sqlite3_bind_text(context, valueIndex(1), e.id.utf8String, -1, nil) != SQLITE_OK {
-                assertionWithLastErrorMessage()
-                return
-            }
-
-            if sqlite3_bind_text(context, valueIndex(2), e.destination.utf8String, -1, nil) != SQLITE_OK {
-                assertionWithLastErrorMessage()
-                return
-            }
-
-            if sqlite3_bind_int64(
-                context, valueIndex(3), sqlite3_int64(e.timestamp.timeIntervalSince1970)
-            ) != SQLITE_OK {
-                assertionWithLastErrorMessage()
-                return
-            }
-
-            if sqlite3_bind_text(context, valueIndex(4), e.eventName.utf8String, -1, nil) != SQLITE_OK {
-                assertionWithLastErrorMessage()
-                return
-            }
-
-            do {
-                let parameters = try JSONSerialization.data(withJSONObject: e.parameters)
-                if
-                    let string = String(data: parameters, encoding: .utf8),
-                    sqlite3_bind_text(context, valueIndex(5), string, -1, nil) != SQLITE_OK
-                {
-                    assertionWithLastErrorMessage()
-                    return
+    public func save(_ e: [BufferRecord]) throws {
+        try db.run(
+            try events.insertMany(
+                e.map {
+                    let parameters: Data
+                    if JSONSerialization.isValidJSONObject($0.parameters) {
+                        parameters = try JSONSerialization.data(withJSONObject: $0.parameters)
+                    } else {
+                        parameters = .init()
+                    }
+                    return [
+                        Column.id <- $0.id,
+                        Column.destination <- $0.destination,
+                        Column.eventName <- $0.eventName,
+                        Column.parameters <- parameters,
+                        Column.timestamp <- $0.timestamp
+                    ]
                 }
-            } catch {
-                assertionIfDebugMode("\(error).")
-                return
-            }
-        }
-
-        if sqlite3_step(context) != SQLITE_DONE {
-            assertionWithLastErrorMessage()
-            return
-        }
+            )
+        )
     }
 
-    public func load(limit: Int64) async -> [BufferRecord] {
-        let query: String
-        if limit < 0 {
-            query = "SELECT * FROM Events ORDER BY timestamp"
-        } else {
-            query = "SELECT * FROM Events ORDER BY timestamp LIMIT ?"
-        }
-        let context = prepare(query: query)
-
-        defer {
-            sqlite3_finalize(context)
-        }
-
-        if limit > 0, sqlite3_bind_int64(context, 1, Int64(limit)) != SQLITE_OK {
-            assertionWithLastErrorMessage()
-            return []
-        }
-
-        var result: [BufferRecord] = []
-
-        while sqlite3_step(context) == SQLITE_ROW {
-            let id = String(cString: sqlite3_column_text(context, 0))
-            let destination = String(cString: sqlite3_column_text(context, 1))
-            let timestamp = sqlite3_column_int64(context, 2)
-            let eventName = String(cString: sqlite3_column_text(context, 3))
-
-            let parameters: [String: Sendable] = {
-                guard let bytes = sqlite3_column_blob(context, 4) else { return [:] }
-                let count = Int(sqlite3_column_bytes(context, 4))
-                let data = Data(bytes: bytes, count: count)
-                return (try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Sendable]) ?? [:]
-            }()
-
-            result.append(
-                .init(
-                    id: id,
-                    destination: destination,
-                    eventName: eventName,
-                    parameters: parameters,
-                    timestamp: .init(timeIntervalSince1970: TimeInterval(timestamp)
-                    )
-                )
+    public func load(limit: Int?) throws -> [BufferRecord] {
+        let target = events.order(Column.timestamp).limit(limit)
+        let result = try db.prepare(target).map { row in
+            let p = try JSONSerialization.jsonObject(with: row[Column.parameters])
+            return BufferRecord(
+                id: row[Column.id],
+                destination: row[Column.destination],
+                eventName: row[Column.eventName],
+                parameters: p as! [String: Sendable],
+                timestamp: row[Column.timestamp]
             )
         }
 
-        let success = delete(result.map(\.id))
-        return success ? result : []
-    }
-
-    public func count() async -> Int {
-        let query = "SELECT COUNT(*) FROM Events"
-        let context = prepare(query: query)
-
-        defer {
-            sqlite3_finalize(context)
-        }
-
-        if sqlite3_step(context) != SQLITE_ROW {
-            assertionWithLastErrorMessage()
-            return 0
-        }
-
-        let result = Int(sqlite3_column_int64(context, 0))
+        if limit != nil {
+            // Cannot Delete if limit is not specified
+            try db.run(target.delete())
+        } else {
+            try db.run(events.delete())        }
 
         return result
     }
 
-    private func prepare(query: String, option: Int32 = SQLITE_PREPARE_PERSISTENT) -> OpaquePointer? {
-        var context: OpaquePointer?
-
-        if sqlite3_prepare_v3(
-            dbPointer,
-            query,
-            -1,
-            UInt32(option),
-            &context,
-            nil
-        ) != SQLITE_OK {
-            assertionWithLastErrorMessage()
-        }
-
-        return context
+    public func count() throws -> Int {
+        try db.scalar(events.count)
     }
 
-    private func delete(_ IDs: [String]) -> Bool {
-        guard IDs.count > 0 else { return true }
-        let query = """
-        DELETE FROM Events WHERE \(IDs.map { _ in "id = ?" }.joined(separator: " OR "))
-        """
-
-        let context = prepare(query: query)
-
-        defer {
-            sqlite3_finalize(context)
-        }
-
-        for (index, id) in IDs.enumerated()
-            where sqlite3_bind_text(context, Int32(index + 1), id.utf8String, -1, nil) != SQLITE_OK {
-            assertionWithLastErrorMessage()
-            return false
-        }
-
-        if sqlite3_step(context) != SQLITE_DONE {
-            assertionWithLastErrorMessage()
-            return false
-        } else {
-            return true
-        }
-    }
-
-    private func assertionWithLastErrorMessage() {
-        let error = String(cString: sqlite3_errmsg(dbPointer))
-        assertionIfDebugMode("\(error).This is probably a programming error.")
-    }
-}
-
-extension SQLiteBuffer {
-    func clear() {
-        let query = "DELETE FROM Events"
-        let context = prepare(query: query)
-
-        if sqlite3_step(context) != SQLITE_DONE {
-            assertionWithLastErrorMessage()
-            return
-        }
-    }
-}
-
-extension String {
-    // https://stackoverflow.com/questions/28142226/sqlite-for-swift-is-unstable
-    var utf8String: UnsafePointer<CChar>? {
-        (self as NSString).utf8String
-    }
-}
-
-func assertionIfDebugMode(_ msg: String) {
-    Task { @MainActor in
-        assert(Configuration.debugMode, msg)
+    public func clear() throws {
+        try db.run(events.drop())
     }
 }

--- a/Tests/ParchmentDefaultTests/RegularlyPollingSchedulerTests.swift
+++ b/Tests/ParchmentDefaultTests/RegularlyPollingSchedulerTests.swift
@@ -17,8 +17,13 @@ final class EventQueueMock: TrackingEventBuffer, @unchecked Sendable {
         records += e
     }
 
-    func load(limit: Int64) -> [BufferRecord] {
-        let count = limit > 0 ? Int(limit) : records.count
+    func load(limit: Int?) async throws -> [Parchment.BufferRecord] {
+        let count: Int
+        if let limit {
+            count = limit
+        } else {
+            count = records.count
+        }
         return (0 ..< min(count, records.count)).reduce([]) { result, _ in
             result + [dequeue()].compactMap { $0 }
         }

--- a/Tests/ParchmentTests/Stub.swift
+++ b/Tests/ParchmentTests/Stub.swift
@@ -39,8 +39,13 @@ final class EventQueueMock: TrackingEventBuffer, @unchecked Sendable {
         records += e
     }
 
-    func load(limit: Int64) -> [BufferRecord] {
-        let count = limit > 0 ? Int(limit) : records.count
+    func load(limit: Int?) async throws -> [Parchment.BufferRecord] {
+        let count: Int
+        if let limit {
+            count = limit
+        } else {
+            count = records.count
+        }
         return (0 ..< min(count, records.count)).reduce([]) { result, _ in
             result + [dequeue()].compactMap { $0 }
         }
@@ -75,7 +80,7 @@ final class BufferedEventFlushStrategyMock: BufferedEventFlushScheduler, @unchec
     func cancel() {}
 
     func flush() async {
-        let events = await buffer!.load(limit: .max)
+        let events = try! await buffer!.load()
         continuation?.yield(events)
     }
 }


### PR DESCRIPTION
Direct dependence on SQLite2 is expensive to maintain.
Since the essential value we want to provide with this library is not a database implementation, we decided to use an existing good database implementation.